### PR TITLE
Add key binding for navigation to parent location

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## WiP
+
+**Released: WiP**
+
+- Added <kbd>backspace</kbd> as a navigation shortcut for "change to parent"
+  ([thanks to ihabunek](https://github.com/davep/textual-fspicker/pull/7)).
+
 ## v0.0.10
 
 **Released: 2023-08-07**

--- a/textual_fspicker/parts/directory_navigation.py
+++ b/textual_fspicker/parts/directory_navigation.py
@@ -186,6 +186,10 @@ class DirectoryNavigation(OptionList):
     a file.
     """
 
+    BINDINGS = [
+        ("backspace", "navigate_up"),
+    ]
+
     COMPONENT_CLASSES: ClassVar[set[str]] = {
         "directory-navigation--hidden",
         "directory-navigation--name",
@@ -337,6 +341,10 @@ class DirectoryNavigation(OptionList):
         # Either there is no custom filter, or whatever we're looking at
         # passed so far; not do final checks.
         return self.is_hidden(path) and not self.show_hidden
+
+    def action_navigate_up(self):
+        """Navigate to the parent location"""
+        self._location = self._location.parent
 
     def _sort(self, entries: Iterable[DirectoryEntry]) -> Iterable[DirectoryEntry]:
         """Sort the entries as per the value of `sort_display`."""


### PR DESCRIPTION
Backspace is a common binding for navigating to parent location in file manager apps such as Krusader and Double Commander. Probably stemming from Total Commander.