### PR TITLE
Fix the way the directory label in `SelectDirectory` updates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Fixed the cosmetics of the directory label in `SelectDirectory`.
+
 ## v0.1.0
 
 **Released: 2025-01-15**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 **Released: WiP**
 
 - Fixed the cosmetics of the directory label in `SelectDirectory`.
+  ([#15](https://github.com/davep/textual-fspicker/pull/15))
 
 ## v0.1.0
 

--- a/src/textual_fspicker/select_directory.py
+++ b/src/textual_fspicker/select_directory.py
@@ -48,7 +48,7 @@ class CurrentDirectory(Label):
             )
             >= self.size.width
         ):
-            display = "…" + display[1:]
+            display = f"…{display[1:]}"
         self.update(display)
 
     def on_resize(self) -> None:


### PR DESCRIPTION
It was supposed to be a single line, and truncate at the start if necessary. It looks like something's changed with labels in Textual since I first wrote this code, and also the truncation didn't ever survive a resize of the window.

This fixes that.