### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/style-and-lint.yaml
+++ b/.github/workflows/style-and-lint.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 - Added `default_file` to `FileOpen` and `FileSave`.
   ([#18](https://github.com/davep/textual-fspicker/pull/18))
 - Dropped support for Python 3.8.
+  ([#19](https://github.com/davep/textual-fspicker/pull/19))
 
 ## v0.1.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
 - Added `default_file` to `FileOpen` and `FileSave`.
   ([#18](https://github.com/davep/textual-fspicker/pull/18))
+- Dropped support for Python 3.8.
 
 ## v0.1.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "textual>=1.0.0",
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "License :: OSI Approved :: MIT License" }
 keywords = [
     "terminal",
@@ -24,7 +24,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Python 3.8 is now end-of-life; so drop it.