### PR TITLE
Handle Windows throwing an OSError on dodgy mtime

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Handled Windows throwing an `OSError` when `mtime` can't be adequately
+  worked out.
+  ([6#issuecomment-2669234263](https://github.com/davep/textual-fspicker/issues/6#issuecomment-2669234263))
+
 ## v0.2.0
 
 **Released: 2025-01-30**

--- a/src/textual_fspicker/parts/directory_navigation.py
+++ b/src/textual_fspicker/parts/directory_navigation.py
@@ -99,7 +99,16 @@ class DirectoryEntry(Option):
             mtime = location.stat().st_mtime
         except FileNotFoundError:
             mtime = 0
-        return datetime.fromtimestamp(int(mtime)).isoformat().replace("T", " ")
+        try:
+            mdatetime = datetime.fromtimestamp(int(mtime))
+        except OSError:
+            # It's possible, on Windows anyway, for the attempt to convert a
+            # time like this to throw an OSError. So we'll capture that and
+            # default to the epoch.
+            #
+            # https://github.com/davep/textual-fspicker/issues/6#issuecomment-2669234263
+            mdatetime = datetime.fromtimestamp(0)
+        return mdatetime.isoformat().replace("T", " ")
 
     @staticmethod
     def _size(location: Path) -> str:


### PR DESCRIPTION
See https://github.com/davep/textual-fspicker/issues/6#issuecomment-2669234263