### PR TITLE
More older Python tweaks

### DIFF
--- a/.github/workflows/style-and-lint.yaml
+++ b/.github/workflows/style-and-lint.yaml
@@ -34,7 +34,9 @@ jobs:
           version: "latest"
 
       - name: Install Dependencies
-        run: make setup
+        run: |
+          echo ${{ matrix.python-version }} > .python-version
+          make setup
 
       - name: Check for typos
         run: make spellcheck

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## v0.4.3
+
+**Released: 2025-08-08**
+
+- Fixed crash with Python 3.9 (redux).
+  ([#55](https://github.com/davep/textual-fspicker/issues/55))
+
 ## v0.4.2
 
 **Released: 2025-08-07**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "textual-fspicker"
-version = "0.4.2"
+version = "0.4.3"
 description = "A simple Textual filesystem picker dialog library."
 authors = [
     { name = "Dave Pearson", email = "davep@davep.org" }

--- a/src/textual_fspicker/base_dialog.py
+++ b/src/textual_fspicker/base_dialog.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 # Python imports.
 import sys
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Union
 
 ##############################################################################
 # Textual imports.
@@ -39,12 +39,12 @@ class InputBar(Horizontal):
 
 
 ##############################################################################
-ButtonLabel: TypeAlias = str | Callable[[str], str]
+ButtonLabel: TypeAlias = Union[str, Callable[[str], str]]
 """The type for a button label value."""
 
 
 ##############################################################################
-class FileSystemPickerScreen(ModalScreen[Path | None]):
+class FileSystemPickerScreen(ModalScreen[Union[Path, None]]):
     """Base screen for the dialogs in this library."""
 
     DEFAULT_CSS = """


### PR DESCRIPTION
Looks like there are other issues with Python 3.9. Despite the fact that [it's almost EOL](https://devguide.python.org/versions/) let's try and stay compatible with 3.9 for a wee bit longer.

This PR also addresses the fact that the workflow configuration wasn't correctly setting the Python version when performing tests against each one. This might help catch some other problems.

Closes #55 again.