### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/style-and-lint.yaml
+++ b/.github/workflows/style-and-lint.yaml
@@ -14,6 +14,8 @@ jobs:
 
     name: Style and lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]


### PR DESCRIPTION
Potential fix for [https://github.com/davep/textual-fspicker/security/code-scanning/1](https://github.com/davep/textual-fspicker/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block and restrict the GITHUB_TOKEN to the least privileges needed. For this workflow, it only checks out and reads the code and runs local tooling, so it only needs read access to repository contents. This can be set at the workflow level (applies to all jobs) or the job level; since there is a single job, adding it at the job level is clear and minimal.

The single best fix with minimal behavioral change is to add a `permissions` block under the `style-lint-and-test` job, aligned with `runs-on` and `strategy`, setting `contents: read`. No other scopes are required based on the current steps. Concretely, in `.github/workflows/style-and-lint.yaml`, between `runs-on: ubuntu-latest` (line 16) and `strategy:` (line 17), insert:

```yaml
    permissions:
      contents: read
```

No imports, methods, or additional definitions are needed because this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
