### PR TITLE
:card_index: Relax the version requirements for uv_build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Issues = "https://github.com/davep/textual-fspicker/issues"
 Discussions = "https://github.com/davep/textual-fspicker/discussions"
 
 [build-system]
-requires = ["uv_build>=0.8.11,<0.9.0"]
+requires = ["uv_build>=0.8.11"]
 build-backend = "uv_build"
 
 [tool.uv]


### PR DESCRIPTION
I honestly don't know why they do it like this by default anyway.

Closes #89.
