### PR TITLE
Avoid crash when styles aren't available yet

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## v1.0.1
+
+**Released: 2026-05-20**
+
+- Worked around a crash in a particular GNU/Linux environment. ([thanks to
+  zvonler-sfw](https://github.com/davep/textual-fspicker/pull/97))
+
 ## v1.0.0
 
 **Released: 2026-02-18**

--- a/src/textual_fspicker/parts/directory_navigation.py
+++ b/src/textual_fspicker/parts/directory_navigation.py
@@ -377,9 +377,15 @@ class DirectoryNavigation(OptionList):
         try:
             return DirectoryEntryStyling(
                 self.get_component_rich_style("directory-navigation--hidden"),
-                self.get_component_rich_style("directory-navigation--name", partial=True),
-                self.get_component_rich_style("directory-navigation--size", partial=True),
-                self.get_component_rich_style("directory-navigation--time", partial=True),
+                self.get_component_rich_style(
+                    "directory-navigation--name", partial=True
+                ),
+                self.get_component_rich_style(
+                    "directory-navigation--size", partial=True
+                ),
+                self.get_component_rich_style(
+                    "directory-navigation--time", partial=True
+                ),
             )
         except KeyError:
             return DirectoryEntryStyling(Style(), Style(), Style(), Style())

--- a/src/textual_fspicker/parts/directory_navigation.py
+++ b/src/textual_fspicker/parts/directory_navigation.py
@@ -374,12 +374,15 @@ class DirectoryNavigation(OptionList):
     @property
     def _styles(self) -> DirectoryEntryStyling:
         """The styles to use for a directory entry."""
-        return DirectoryEntryStyling(
-            self.get_component_rich_style("directory-navigation--hidden"),
-            self.get_component_rich_style("directory-navigation--name", partial=True),
-            self.get_component_rich_style("directory-navigation--size", partial=True),
-            self.get_component_rich_style("directory-navigation--time", partial=True),
-        )
+        try:
+            return DirectoryEntryStyling(
+                self.get_component_rich_style("directory-navigation--hidden"),
+                self.get_component_rich_style("directory-navigation--name", partial=True),
+                self.get_component_rich_style("directory-navigation--size", partial=True),
+                self.get_component_rich_style("directory-navigation--time", partial=True),
+            )
+        except KeyError:
+            return DirectoryEntryStyling(Style(), Style(), Style(), Style())
 
     def _repopulate_display(self) -> None:
         """Repopulate the display of directories."""


### PR DESCRIPTION

Fixes a frequent but intermittent crash when using the dialogs in an emulated virtual machine. Discussion here https://github.com/davep/textual-fspicker/discussions/96

Please include this fix in a v0.6.1 release so that it can be picked up by systems still on Python 3.9.